### PR TITLE
Read existing properties when updating access rule

### DIFF
--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2777,11 +2777,19 @@ impl Room {
 
     // Tchap-specific : access_rules
     /// Set or update the access rule for this room.
+    /// We get the value of other acces rule properties (visiblity and encrypted)
+    /// to transmit them to the new RoomAccessRulesEventContent in order to not replace
+    /// existing values with default ones.
+    /// This method is called by client only on an existing room (it is not used on room creation).
+    /// So, the 2 other properties already have a meaningfull value.
     pub async fn set_access_rule(
         &self,
         access_rule: AccessRule,
     ) -> Result<send_state_event::v3::Response> {
-        self.send_state_event(RoomAccessRulesEventContent::new(access_rule)).await
+        self.send_state_event(RoomAccessRulesEventContent { 
+            access_rule: access_rule,
+            visibility: Some(self.visibility().await),
+            encrypted: Some(self.is_encrypted().await) }).await
     }
 
     /// Get the access rule event content for this room.

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2786,10 +2786,20 @@ impl Room {
         &self,
         access_rule: AccessRule,
     ) -> Result<send_state_event::v3::Response> {
-        self.send_state_event(RoomAccessRulesEventContent { 
-            access_rule: access_rule,
-            visibility: Some(self.visibility().await),
-            encrypted: Some(self.is_encrypted().await) }).await
+        let (encrypted, visibility) = match self.full_access_rules().await {
+            Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (None, None),
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
+                (e.content.encrypted, e.content.visibility)
+            }
+            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
+                PossiblyRedactedRoomAccessRulesEventContent { encrypted, visibility, .. } => {
+                    (encrypted, visibility)
+                }
+            },
+        };
+
+        self.send_state_event(RoomAccessRulesEventContent { access_rule, visibility, encrypted })
+            .await
     }
 
     /// Get the access rule event content for this room.
@@ -2808,7 +2818,7 @@ impl Room {
         match self.full_access_rules().await {
             Err(e) => return Err(e),
             Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) =>
-                Ok(e.content.access_rule.clone()),
+                Ok(e.content.access_rule),
             Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) =>
                 Err(Error::InsufficientData),
             Ok(SyncOrStrippedState::Stripped(e)) => match e.content {


### PR DESCRIPTION
When updating access_rule, read other values (encrypted and visibility) to use them on update to avoid overriding them.