### PR TITLE
Tchap specific - Invite user by email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,6 +1519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "emojis"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3425,7 @@ dependencies = [
  "anyhow",
  "async-compat",
  "console_error_panic_hook",
+ "email_address",
  "extension-trait",
  "eyeball-im",
  "futures-executor",
@@ -3628,6 +3638,7 @@ dependencies = [
  "futures-util",
  "reqwest",
  "ruma",
+ "ruma-common",
  "serde",
  "serde_json",
  "thiserror 2.0.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ matrix-sdk-search = { path = "crates/matrix-sdk-search", version = "0.15.0" }
 
 # Tchap-specific
 matrix-sdk-tchap = { path = "crates/matrix-sdk-tchap", version = "0.1.0", default-features = false }
+ruma-common = { version = "0.17.0" }
 # end Tchap-specific
 
 [workspace.lints.rust]

--- a/bindings/matrix-sdk-ffi/Cargo.toml
+++ b/bindings/matrix-sdk-ffi/Cargo.toml
@@ -65,7 +65,8 @@ matrix-sdk-ffi-macros.workspace = true
 matrix-sdk-ui = { workspace = true, features = ["uniffi"] }
 
 # Tchap-specific
-matrix-sdk-tchap = { workspace = true }
+matrix-sdk-tchap = { workspace = true, features = ["client"] }
+email_address = "0.2.9"
 # end Tchap-specific
 
 mime = "0.3.17"

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -27,6 +27,7 @@ use matrix_sdk_ui::{
 };
 use mime::Mime;
 use ruma::{
+    api::client::membership::Invite3pidInit,
     assign,
     events::{
         receipt::ReceiptThread,
@@ -38,8 +39,8 @@ use ruma::{
         },
         AnyMessageLikeEventContent, AnySyncTimelineEvent,
     },
-    EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId, RoomAliasId,
-    ServerName, UserId,
+    thirdparty, EventId, Int, OwnedDeviceId, OwnedRoomOrAliasId, OwnedServerName, OwnedUserId,
+    RoomAliasId, ServerName, UserId,
 };
 use tracing::{error, warn};
 
@@ -66,8 +67,10 @@ use crate::{
     TaskHandle,
 };
 
-// Tchap-specific : permalinks
+// Tchap-specific : permalinks & invite_users_by_email
+use email_address::EmailAddress;
 use matrix_sdk_tchap::permalinks::MatrixToUriToTchapString;
+use ruma::api::client::account::request_openid_token::v3::Request as OpenIdRequest;
 // end Tchap-specific
 
 mod power_levels;
@@ -614,6 +617,76 @@ impl Room {
         self.inner.invite_user_by_id(user).await?;
         Ok(())
     }
+
+    // Tchap-specific : invite_users_by_email
+    pub async fn invite_user_by_email(&self, email_to_invite: String) -> Result<(), ClientError> {
+        self.invite_users_by_email(vec![email_to_invite]).await?;
+        Ok(())
+    }
+
+    pub async fn invite_users_by_email(
+        &self,
+        emails_to_invite: Vec<String>,
+    ) -> Result<(), ClientError> {
+        // Get openIdToken
+        let user_id = self.inner.own_user_id().to_owned();
+        let open_id_response = self.inner.client().send(OpenIdRequest::new(user_id)).await?;
+
+        // Exchanges the OpenID token for an access token to access the identity server
+        let account_register_response = self
+            .inner
+            .client()
+            .send(matrix_sdk_tchap::request::identity_account_register::v1::Request::new(
+                open_id_response,
+            ))
+            .await?;
+
+        if account_register_response.token.is_empty() {
+            return Err(ClientError::Generic {
+                msg: "No identity server token given back".to_owned(),
+                details: None,
+            });
+        }
+
+        let homeserver =
+            matrix_sdk::sanitize_server_name(&self.inner.client().homeserver().as_str())
+                .unwrap()
+                .to_string();
+
+        // For email in emails_to_invite, send the invite
+        let (valid_emails, mut invalid_emails): (Vec<_>, Vec<_>) =
+            emails_to_invite.into_iter().partition(|email| EmailAddress::is_valid(email.as_str()));
+
+        for email in valid_emails {
+            if self
+                .inner
+                .invite_user_by_3pid(
+                    Invite3pidInit {
+                        id_server: homeserver.clone(),
+                        id_access_token: account_register_response.token.clone(),
+                        medium: thirdparty::Medium::Email,
+                        address: email.to_owned(),
+                    }
+                    .into(),
+                )
+                .await
+                .is_err()
+            {
+                invalid_emails.push(email);
+            }
+        }
+
+        // If one or more invitations failed, return an error
+        if !invalid_emails.is_empty() {
+            return Err(ClientError::Generic {
+                msg: "Some emails were not valid".to_owned(),
+                details: Some(invalid_emails.join(";")),
+            });
+        }
+
+        Ok(())
+    }
+    // end Tchap-specific
 
     pub async fn ban_user(
         &self,

--- a/crates/matrix-sdk-tchap/Cargo.toml
+++ b/crates/matrix-sdk-tchap/Cargo.toml
@@ -17,6 +17,7 @@ futures-core = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 ruma = { workspace = true }
+ruma-common = { workspace = true, features = ["api"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/matrix-sdk-tchap/src/request/identity_account_register.rs
+++ b/crates/matrix-sdk-tchap/src/request/identity_account_register.rs
@@ -1,0 +1,96 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025. DINUM
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+//! `POST /_matrix/identity/v2/account/register`
+//!
+//! Exchanges an OpenID token from the homeserver for an access token to access the identity server.
+
+pub mod v1 {
+    //! `/v2/` ([spec])
+    //!
+    //! [spec]: https://spec.matrix.org/latest/identity-service-api/#post_matrixidentityv2accountregister
+
+    use ruma::{
+        api::client::account::request_openid_token::v3::Response as OpenIdResponse,
+        authentication::TokenType, OwnedServerName,
+    };
+    use std::time::Duration;
+
+    use ruma_common::{
+        api::{auth_scheme::AccessToken, request, response},
+        metadata,
+    };
+
+    metadata! {
+        method: POST,
+        rate_limited: false,
+        authentication: AccessToken,
+        history: {
+            1.0 => "/_matrix/identity/v2/account/register",
+        }
+    }
+
+    /// Request type for the `identity_account_register` endpoint.
+    #[request(error=ruma_common::api::error::MatrixError)]
+    pub struct Request {
+        /// Access token for verifying user's identity.
+        pub access_token: String,
+
+        /// Access token type.
+        pub token_type: TokenType,
+
+        /// Homeserver domain for verification of user's identity.
+        pub matrix_server_name: OwnedServerName,
+
+        /// Seconds until token expiration.
+        #[serde(with = "ruma_common::serde::duration::secs")]
+        pub expires_in: Duration,
+    }
+
+    /// Response type for the `identity_account_register` endpoint.
+    #[response(error=ruma_common::api::error::MatrixError)]
+    pub struct Response {
+        /// The token to authenticate future requests to the identity server with
+        pub token: String,
+    }
+
+    impl Request {
+        /// Creates a new `Request` from an `OpenIdResponse`.
+        pub fn new(data: OpenIdResponse) -> Self {
+            Self {
+                access_token: data.access_token,
+                token_type: data.token_type,
+                matrix_server_name: data.matrix_server_name,
+                expires_in: data.expires_in,
+            }
+        }
+    }
+
+    impl Response {
+        /// Creates a new `Response` with the given token.
+        pub fn new(token: String) -> Self {
+            Self { token }
+        }
+    }
+}

--- a/crates/matrix-sdk-tchap/src/request/mod.rs
+++ b/crates/matrix-sdk-tchap/src/request/mod.rs
@@ -22,8 +22,4 @@
  * OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-pub mod get_instance_from_email;
-pub mod permalinks;
-pub mod request;
-
-uniffi::setup_scaffolding!();
+pub mod identity_account_register;


### PR DESCRIPTION
Allow clients to invite a non-TCHAP user to a room by sending them an email invitation.

- [ ] Public API changes documented in changelogs (optional)

Signed-off-by: @raphael-chevallier 
