### PR TITLE
Fix for room access_rules

### DIFF
--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2853,12 +2853,9 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
         };
 
         let mut content = RoomAccessRulesEventContent::new(access_rule);
-        if !value.is_encrypted {
-            content.encrypted = Some(value.is_encrypted);
-        }
-        if request.visibility != Visibility::Private {
-            content.visibility = Some(request.visibility.clone());
-        }
+        content.encrypted = Some(value.is_encrypted);
+        content.visibility = Some(request.visibility.clone());
+
         initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         // end Tchap-specific
 
@@ -3458,6 +3455,7 @@ mod tests {
             visibility: RoomVisibility::Public,
             // Tchap-specific
             access_rule_override: Some(AccessRule::Restricted),
+            is_room_federated: Some(true),
             // end Tchap-specific
             preset: RoomPreset::PublicChat,
             invite: Some(vec!["@user:example.com".to_owned()]),

--- a/bindings/matrix-sdk-ffi/src/client.rs
+++ b/bindings/matrix-sdk-ffi/src/client.rs
@@ -2793,10 +2793,6 @@ pub struct CreateRoomParameters {
     #[uniffi(default = false)]
     pub is_direct: bool,
     pub visibility: RoomVisibility,
-    // Tchap-specific : access_rules
-    #[uniffi(default = None)]
-    pub access_rule_override: Option<AccessRule>,
-    // end Tchap-specific
     // Tchap-specific : federated param
     #[uniffi(default = None)]
     pub is_room_federated: Option<bool>,
@@ -2846,15 +2842,19 @@ impl TryFrom<CreateRoomParameters> for create_room::v3::Request {
         let mut initial_state: Vec<Raw<AnyInitialStateEvent>> = vec![];
 
         // Tchap-specific : access_rules
-        let access_rule = if let Some(access_rule_override) = value.access_rule_override {
-            access_rule_override
-        } else {
-            AccessRule::Restricted
-        };
+        // Rule is always Restricted at creation for private & public rooms, and Direct for DM.
+        // Can be Unrestricted later, when opening to extrernal users.
+        let access_rule =
+            if request.is_direct { AccessRule::Direct } else { AccessRule::Restricted };
 
         let mut content = RoomAccessRulesEventContent::new(access_rule);
-        content.encrypted = Some(value.is_encrypted);
         content.visibility = Some(request.visibility.clone());
+
+        // By default Tchap servers will force encryption at creation for private room.
+        // Set this attribute to true for private unencrypted rooms type.
+        if request.visibility == Visibility::Private && !value.is_encrypted {
+            content.force_unencrypted_at_creation = Some(true);
+        }
 
         initial_state.push(InitialStateEvent::with_empty_state_key(content).to_raw_any());
         // end Tchap-specific

--- a/bindings/matrix-sdk-ffi/src/room/mod.rs
+++ b/bindings/matrix-sdk-ffi/src/room/mod.rs
@@ -39,8 +39,8 @@ use matrix_sdk_ui::{
 };
 use mime::Mime;
 use ruma::{
-    api::client::threads::get_threads::v1::IncludeThreads as SdkIncludeThreads,
     api::client::membership::Invite3pidInit,
+    api::client::threads::get_threads::v1::IncludeThreads as SdkIncludeThreads,
     assign,
     events::{
         receipt::ReceiptThread,
@@ -568,21 +568,6 @@ impl Room {
     pub async fn set_access_rule(&self, rule: AccessRule) -> Result<(), ClientError> {
         self.inner.set_access_rule(rule).await?;
         Ok(())
-    }
-
-    // Get the room access rule
-    pub async fn get_access_rule(&self) -> Result<AccessRule, ClientError> {
-        Ok(self.inner.access_rule().await?)
-    }
-
-    // Get the room access rule
-    pub async fn get_is_encrypted(&self) -> bool {
-        self.inner.is_encrypted().await
-    }
-
-    // Get the room access rule
-    pub async fn get_visibility(&self) -> RoomVisibility {
-        self.inner.visibility().await.into()
     }
     // end Tchap-specific
 

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 
 use matrix_sdk::{room::access_rules::AccessRule, EncryptionState, RoomState};
-use tokio::join;
 use tracing::warn;
 
 use crate::{
@@ -132,9 +131,8 @@ impl RoomInfo {
             .map(|p| RoomPowerLevels::new(p, room.own_user_id().to_owned()));
 
         // Tchap-specific
-        // Get AccessRule value.
-        let (access_rule, is_encrypted, visibility) =
-            join!(room.access_rule(), room.is_encrypted(), room.visibility());
+        // Get AccessRules values.
+        let (access_rule, is_encrypted, visibility) = room.get_access_rules().await;
         // end Tchap-specific
 
         Ok(Self {

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use matrix_sdk::{room::access_rules::AccessRule, EncryptionState, RoomState};
+use tokio::join;
 use tracing::warn;
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
     error::ClientError,
     notification_settings::RoomNotificationMode,
     room::{
-        Membership, RoomHero, RoomHistoryVisibility, SuccessorRoom, power_levels::RoomPowerLevels
+        power_levels::RoomPowerLevels, Membership, RoomHero, RoomHistoryVisibility, SuccessorRoom,
     },
     room_member::RoomMember,
 };
@@ -103,7 +104,7 @@ pub struct RoomInfo {
     ///    - visiblity: is the room visible in public directories
     access_rule: Option<AccessRule>,
     is_encrypted: bool,
-    visiblity: RoomVisibility
+    visiblity: RoomVisibility,
     // end Tchap-specific
 }
 
@@ -132,9 +133,8 @@ impl RoomInfo {
 
         // Tchap-specific
         // Get AccessRule value.
-        let access_rule = room.access_rule().await.ok();
-        let is_encrypted = room.is_encrypted().await;
-        let visibility = room.visibility().await; 
+        let (access_rule, is_encrypted, visibility) =
+            join!(room.access_rule(), room.is_encrypted(), room.visibility());
         // end Tchap-specific
 
         Ok(Self {
@@ -204,9 +204,9 @@ impl RoomInfo {
                 .map(|rules| rules.authorization.explicitly_privilege_room_creators)
                 .unwrap_or_default(),
             // Tchap-specific
-            access_rule: access_rule, 
+            access_rule: access_rule.ok(),
             is_encrypted: is_encrypted,
-            visiblity: visibility.into()
+            visiblity: visibility.into(),
             // end Tchap-specific
         })
     }

--- a/bindings/matrix-sdk-ffi/src/room/room_info.rs
+++ b/bindings/matrix-sdk-ffi/src/room/room_info.rs
@@ -101,7 +101,7 @@ pub struct RoomInfo {
     ///    - access_rule: is the room open to external user
     ///    - is_encrypted: is the room encrypted or not
     ///    - visiblity: is the room visible in public directories
-    access_rule: Option<AccessRule>,
+    access_rule: AccessRule,
     is_encrypted: bool,
     visiblity: RoomVisibility,
     // end Tchap-specific
@@ -202,7 +202,7 @@ impl RoomInfo {
                 .map(|rules| rules.authorization.explicitly_privilege_room_creators)
                 .unwrap_or_default(),
             // Tchap-specific
-            access_rule: access_rule.ok(),
+            access_rule: access_rule,
             is_encrypted: is_encrypted,
             visiblity: visibility.into(),
             // end Tchap-specific

--- a/crates/matrix-sdk/src/room/access_rules.rs
+++ b/crates/matrix-sdk/src/room/access_rules.rs
@@ -2,7 +2,7 @@
 
 use ruma::{
     api::client::room::Visibility,
-    events::{macros::EventContent, EmptyStateKey},
+    events::{EmptyStateKey, macros::EventContent},
 };
 use serde::{Deserialize, Serialize};
 
@@ -39,10 +39,10 @@ pub struct RoomAccessRulesEventContent {
     /// The type of rules used for external users wishing to join this room.
     #[serde(rename = "rule")] // The key name awaited by Synapse. Mandatory!
     pub access_rule: Option<AccessRule>,
-    /// Allow to specify if a room should be unencrypted.
+    /// Allow to specify if a private room should be forced to be unencrypted.
     /// By default Tchap servers will force encryption when creating a private room or a DM,
-    /// except if this attribute is explicitly set to false.
-    pub encrypted: Option<bool>,
+    /// except if this attribute is explicitly set to true for private unencrypted rooms type.
+    pub force_unencrypted_at_creation: Option<bool>,
     /// This reflects if the room is visible in the public room directory.
     /// We need this in a room state event, otherwise we have to manually regularly pull
     /// the public dir endpoint, which is inefficient, not real time and error prone.
@@ -53,7 +53,11 @@ pub struct RoomAccessRulesEventContent {
 impl RoomAccessRulesEventContent {
     /// Creates a new `RoomAccessRulesEventContent` with the given rule.
     pub fn new(access_rule: AccessRule) -> Self {
-        Self { access_rule: Some(access_rule), encrypted: None, visibility: None }
+        Self {
+            access_rule: Some(access_rule),
+            force_unencrypted_at_creation: None,
+            visibility: None,
+        }
     }
 }
 
@@ -71,7 +75,7 @@ mod tests {
             event,
             RoomAccessRulesEventContent {
                 access_rule: Some(AccessRule::Unrestricted),
-                encrypted: None,
+                force_unencrypted_at_creation: None,
                 visibility: None
             }
         );
@@ -85,7 +89,7 @@ mod tests {
             access_rules,
             RoomAccessRulesEventContent {
                 access_rule: Some(AccessRule::Restricted),
-                encrypted: None,
+                force_unencrypted_at_creation: None,
                 visibility: None
             }
         );
@@ -99,7 +103,7 @@ mod tests {
             access_rules,
             RoomAccessRulesEventContent {
                 access_rule: Some(AccessRule::Direct),
-                encrypted: None,
+                force_unencrypted_at_creation: None,
                 visibility: None
             }
         );

--- a/crates/matrix-sdk/src/room/access_rules.rs
+++ b/crates/matrix-sdk/src/room/access_rules.rs
@@ -38,7 +38,7 @@ impl AccessRule {}
 pub struct RoomAccessRulesEventContent {
     /// The type of rules used for external users wishing to join this room.
     #[serde(rename = "rule")] // The key name awaited by Synapse. Mandatory!
-    pub access_rule: AccessRule,
+    pub access_rule: Option<AccessRule>,
     /// Allow to specify if a room should be unencrypted.
     /// By default Tchap servers will force encryption when creating a private room or a DM,
     /// except if this attribute is explicitly set to false.
@@ -53,7 +53,7 @@ pub struct RoomAccessRulesEventContent {
 impl RoomAccessRulesEventContent {
     /// Creates a new `RoomAccessRulesEventContent` with the given rule.
     pub fn new(access_rule: AccessRule) -> Self {
-        Self { access_rule, encrypted: None, visibility: None }
+        Self { access_rule: Some(access_rule), encrypted: None, visibility: None }
     }
 }
 
@@ -70,7 +70,7 @@ mod tests {
         assert_matches!(
             event,
             RoomAccessRulesEventContent {
-                access_rule: AccessRule::Unrestricted,
+                access_rule: Some(AccessRule::Unrestricted),
                 encrypted: None,
                 visibility: None
             }
@@ -84,7 +84,7 @@ mod tests {
         assert_matches!(
             access_rules,
             RoomAccessRulesEventContent {
-                access_rule: AccessRule::Restricted,
+                access_rule: Some(AccessRule::Restricted),
                 encrypted: None,
                 visibility: None
             }
@@ -98,7 +98,7 @@ mod tests {
         assert_matches!(
             access_rules,
             RoomAccessRulesEventContent {
-                access_rule: AccessRule::Direct,
+                access_rule: Some(AccessRule::Direct),
                 encrypted: None,
                 visibility: None
             }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2963,8 +2963,12 @@ impl Room {
             },
         };
 
-        self.send_state_event(RoomAccessRulesEventContent { access_rule, visibility, encrypted })
-            .await
+        self.send_state_event(RoomAccessRulesEventContent {
+            access_rule: Some(access_rule),
+            visibility,
+            encrypted,
+        })
+        .await
     }
 
     /// Get the access_rules event content for this room.
@@ -2982,24 +2986,22 @@ impl Room {
     }
 
     /// Get the access_rules details (access_rule, encrypted, visibility) for this room.
-    pub async fn get_access_rules(&self) -> (Result<AccessRule, Error>, bool, Visibility) {
-        let (access_rule, encrypted_res, visibility_res) =
+    pub async fn get_access_rules(&self) -> (AccessRule, bool, Visibility) {
+        let (access_rule, encrypted_res, visibility) =
             match self.get_access_rules_event_content().await {
                 Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => (
-                    Ok(e.content.access_rule),
+                    e.content.access_rule.unwrap_or(AccessRule::Restricted),
                     e.content.encrypted.ok_or(Error::InsufficientData),
-                    e.content.visibility.ok_or(Error::InsufficientData),
+                    e.content.visibility.unwrap_or(Visibility::Private),
                 ),
                 Ok(SyncOrStrippedState::Stripped(e)) => (
-                    e.content.access_rule.ok_or(Error::InsufficientData),
+                    e.content.access_rule.unwrap_or(AccessRule::Restricted),
                     e.content.encrypted.ok_or(Error::InsufficientData),
-                    e.content.visibility.ok_or(Error::InsufficientData),
+                    e.content.visibility.unwrap_or(Visibility::Private),
                 ),
-                Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (
-                    Err(Error::InsufficientData),
-                    Err(Error::InsufficientData),
-                    Err(Error::InsufficientData),
-                ),
+                Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
+                    (AccessRule::Restricted, Err(Error::InsufficientData), Visibility::Private)
+                }
             };
 
         // When encrypted_res is in error, check the content of the last room.state.is_encrypted event.
@@ -3011,15 +3013,6 @@ impl Room {
                 .await
                 .map(|state| state.is_encrypted())
                 .unwrap_or(false),
-        };
-
-        // TCHAP TODO : Remove this ugly cheat code when the backend returns complete access_rules (containing visibility state).
-        // When visibility_res is in error, we returns :
-        //     Visibility::Public when room is unencrypted
-        //     Visibility::Private when the room is encrypted.
-        let visibility = match visibility_res {
-            Ok(visibility_value) => visibility_value,
-            Err(_) => encrypted.then_some(Visibility::Private).unwrap_or(Visibility::Public),
         };
 
         (access_rule, encrypted, visibility)

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -180,7 +180,10 @@ use crate::{
     media::{MediaFormat, MediaRequestParameters},
     notification_settings::{IsEncrypted, IsOneToOne, RoomNotificationMode},
     room::{
-        access_rules::PossiblyRedactedRoomAccessRulesEventContent, knock_requests::{KnockRequest, KnockRequestMemberInfo}, power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt}, privacy_settings::RoomPrivacySettings
+        access_rules::PossiblyRedactedRoomAccessRulesEventContent,
+        knock_requests::{KnockRequest, KnockRequestMemberInfo},
+        power_levels::{RoomPowerLevelChanges, RoomPowerLevelsExt},
+        privacy_settings::RoomPrivacySettings,
     },
     sync::RoomUpdate,
     utils::{IntoRawMessageLikeEventContent, IntoRawStateEventContent},
@@ -2965,8 +2968,11 @@ impl Room {
     }
 
     /// Get the access rule event content for this room.
-    async fn full_access_rules(&self) -> Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error> {
-        Ok(self.client
+    async fn full_access_rules(
+        &self,
+    ) -> Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error> {
+        Ok(self
+            .client
             .base_client()
             .state_store()
             .get_state_event_static::<RoomAccessRulesEventContent>(self.room_id())
@@ -2976,46 +2982,55 @@ impl Room {
     }
 
     /// Get the access rule for this room using a prefetched full access rule.
-    async fn access_rule_from_full_access_rule(&self, full_access_rule: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>) -> Result<AccessRule, Error> {
-        match full_access_rule {
+    async fn access_rule_from_full_access_rules(
+        &self,
+        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
+    ) -> Result<AccessRule, Error> {
+        match full_access_rules {
             Err(e) => return Err(e),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) =>
-                Ok(e.content.access_rule),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) =>
-                Err(Error::InsufficientData),
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => Ok(e.content.access_rule),
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
+                Err(Error::InsufficientData)
+            }
             Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { access_rule, .. } => match access_rule {
-                    Some(value) => Ok(value),
-                    None => Err(Error::InsufficientData),
-                },
+                PossiblyRedactedRoomAccessRulesEventContent { access_rule, .. } => {
+                    match access_rule {
+                        Some(value) => Ok(value),
+                        None => Err(Error::InsufficientData),
+                    }
+                }
             },
         }
     }
 
     /// Get the access rule for this room.
     pub async fn access_rule(&self) -> Result<AccessRule, Error> {
-        self.access_rule_from_full_access_rule(self.full_access_rules().await).await
+        self.access_rule_from_full_access_rules(self.full_access_rules().await).await
     }
 
     /// Get the encrypted status for this room using a prefetched full access rule.
     /// Force to true if not defined.
-    async fn is_encrypted_from_full_access_rule(&self, full_access_rule: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>) -> bool {
-        let result = match full_access_rule {
+    async fn is_encrypted_from_full_access_rules(
+        &self,
+        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
+    ) -> bool {
+        let result = match full_access_rules {
             Err(e) => Err(e),
             Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
                 match e.content.encrypted {
                     None => Err(Error::InsufficientData),
                     Some(encrypted_value) => Ok(encrypted_value),
                 }
-            },
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => 
-                Err(Error::InsufficientData),
-            Ok(SyncOrStrippedState::Stripped(e)) =>  match e.content {
+            }
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
+                Err(Error::InsufficientData)
+            }
+            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
                 PossiblyRedactedRoomAccessRulesEventContent { encrypted, .. } => match encrypted {
                     Some(value) => Ok(value),
                     None => Err(Error::InsufficientData),
                 },
-            }
+            },
         };
         match result {
             Ok(encrypted_value) => encrypted_value,
@@ -3025,24 +3040,24 @@ impl Room {
 
     /// Get the encrypted status for this room. Force to true if not defined.
     pub async fn is_encrypted(&self) -> bool {
-        self.is_encrypted_from_full_access_rule(self.full_access_rules().await).await
+        self.is_encrypted_from_full_access_rules(self.full_access_rules().await).await
     }
 
     /// Get the latest encrypted status for this room.
-    /// This method is used as a last chance to get a value in `is_encrypted()` method 
+    /// This method is used as a last chance to get a value in `is_encrypted()` method
     /// if the access rules event in the local store in unable to give a valid value.
-    /// This method makes a request to the server if necessary.
-    /// Consider the room to be not encrypted if real encryption state can't be resolved.
+    /// This method check the content of the last room.state.is_encrypted event.
+    /// Consider the room to be not encrypted if we can't find these type of event, or if the last event content is not valid.
     async fn get_fallback_is_encrypted_value(&self) -> bool {
-        self.latest_encryption_state()
-            .await
-            .map(|state| state.is_encrypted())
-            .unwrap_or(false)
+        self.latest_encryption_state().await.map(|state| state.is_encrypted()).unwrap_or(false)
     }
 
     /// Get the visibility status for this room in the room directory using a prefetched full access rule.
-    async fn visibility_from_full_access_rule(&self, full_access_rule: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>) -> Visibility {
-        let result = match full_access_rule {
+    async fn visibility_from_full_access_rules(
+        &self,
+        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
+    ) -> Visibility {
+        let result = match full_access_rules {
             Err(e) => Err(e),
             Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
                 match e.content.visibility {
@@ -3050,33 +3065,36 @@ impl Room {
                     Some(visibility_value) => Ok(visibility_value),
                 }
             }
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) =>
-                Err(Error::InsufficientData),
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
+                Err(Error::InsufficientData)
+            }
             Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { visibility, .. } => match visibility {
-                    Some(value) => Ok(value),
-                    None => Err(Error::InsufficientData),
-                },
+                PossiblyRedactedRoomAccessRulesEventContent { visibility, .. } => {
+                    match visibility {
+                        Some(value) => Ok(value),
+                        None => Err(Error::InsufficientData),
+                    }
+                }
             },
         };
         match result {
             Ok(visibility_value) => visibility_value,
-            Err(_) => self.get_fallback_room_visibility_value().await
+            Err(_) => self.get_fallback_room_visibility_value().await,
         }
     }
 
     /// Get the visibility status for this room in the room directory.
     pub async fn visibility(&self) -> Visibility {
-        self.visibility_from_full_access_rule(self.full_access_rules().await).await
+        self.visibility_from_full_access_rules(self.full_access_rules().await).await
     }
 
+    // TCHAP TODO : Remove this ugly cheat code when the backend returns complete access_rules (containing visibility state).
     /// Requets the room visibility status for this room.
-    /// This method is used as a last chance to get a value in `visibility()` method 
+    /// This method is used as a last chance to get a value in `visibility()` method
     /// if the access rules event in the local store in unable to give a valid value.
-    /// This method makes a request to the server if necessary.
-    /// Consider the room to be Public if real visibility can't be resolved.
+    /// This method return Visibility::Public when room is unencrypted or Visibility::Private when the room is encrypted.
     async fn get_fallback_room_visibility_value(&self) -> Visibility {
-        self.privacy_settings().get_room_visibility().await.unwrap_or(Visibility::Public)
+        self.is_encrypted().await.then_some(Visibility::Private).unwrap_or(Visibility::Public)
     }
     // end Tchap-specific : access_rules
 

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2951,22 +2951,25 @@ impl Room {
         &self,
         access_rule: AccessRule,
     ) -> Result<send_state_event::v3::Response> {
-        let (encrypted, visibility) = match self.get_access_rules_event_content().await {
-            Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (None, None),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
-                (e.content.encrypted, e.content.visibility)
-            }
-            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { encrypted, visibility, .. } => {
-                    (encrypted, visibility)
+        let (force_unencrypted_at_creation, visibility) =
+            match self.get_access_rules_event_content().await {
+                Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (None, None),
+                Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
+                    (e.content.force_unencrypted_at_creation, e.content.visibility)
                 }
-            },
-        };
+                Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
+                    PossiblyRedactedRoomAccessRulesEventContent {
+                        force_unencrypted_at_creation,
+                        visibility,
+                        ..
+                    } => (force_unencrypted_at_creation, visibility),
+                },
+            };
 
         self.send_state_event(RoomAccessRulesEventContent {
             access_rule: Some(access_rule),
             visibility,
-            encrypted,
+            force_unencrypted_at_creation,
         })
         .await
     }
@@ -2987,33 +2990,24 @@ impl Room {
 
     /// Get the access_rules details (access_rule, encrypted, visibility) for this room.
     pub async fn get_access_rules(&self) -> (AccessRule, bool, Visibility) {
-        let (access_rule, encrypted_res, visibility) =
-            match self.get_access_rules_event_content().await {
-                Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => (
-                    e.content.access_rule.unwrap_or(AccessRule::Restricted),
-                    e.content.encrypted.ok_or(Error::InsufficientData),
-                    e.content.visibility.unwrap_or(Visibility::Private),
-                ),
-                Ok(SyncOrStrippedState::Stripped(e)) => (
-                    e.content.access_rule.unwrap_or(AccessRule::Restricted),
-                    e.content.encrypted.ok_or(Error::InsufficientData),
-                    e.content.visibility.unwrap_or(Visibility::Private),
-                ),
-                Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
-                    (AccessRule::Restricted, Err(Error::InsufficientData), Visibility::Private)
-                }
-            };
-
-        // When encrypted_res is in error, check the content of the last room.state.is_encrypted event.
-        // Consider the room to be not encrypted if we can't find these type of event, or if the last event content is not valid.
-        let encrypted = match encrypted_res {
-            Ok(encrypted_value) => encrypted_value,
-            Err(_) => self
-                .latest_encryption_state()
-                .await
-                .map(|state| state.is_encrypted())
-                .unwrap_or(false),
+        let (access_rule, visibility) = match self.get_access_rules_event_content().await {
+            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => (
+                e.content.access_rule.unwrap_or(AccessRule::Restricted),
+                e.content.visibility.unwrap_or(Visibility::Private),
+            ),
+            Ok(SyncOrStrippedState::Stripped(e)) => (
+                e.content.access_rule.unwrap_or(AccessRule::Restricted),
+                e.content.visibility.unwrap_or(Visibility::Private),
+            ),
+            Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
+                (AccessRule::Restricted, Visibility::Private)
+            }
         };
+
+        // Check the content of the last room.state.is_encrypted event.
+        // Consider the room to be not encrypted if we can't find these type of event, or if the last event content is not valid.
+        let encrypted =
+            self.latest_encryption_state().await.map(|state| state.is_encrypted()).unwrap_or(false);
 
         (access_rule, encrypted, visibility)
     }

--- a/crates/matrix-sdk/src/room/mod.rs
+++ b/crates/matrix-sdk/src/room/mod.rs
@@ -2951,7 +2951,7 @@ impl Room {
         &self,
         access_rule: AccessRule,
     ) -> Result<send_state_event::v3::Response> {
-        let (encrypted, visibility) = match self.full_access_rules().await {
+        let (encrypted, visibility) = match self.get_access_rules_event_content().await {
             Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (None, None),
             Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
                 (e.content.encrypted, e.content.visibility)
@@ -2967,8 +2967,8 @@ impl Room {
             .await
     }
 
-    /// Get the access rule event content for this room.
-    async fn full_access_rules(
+    /// Get the access_rules event content for this room.
+    async fn get_access_rules_event_content(
         &self,
     ) -> Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error> {
         Ok(self
@@ -2981,120 +2981,48 @@ impl Room {
             .deserialize()?)
     }
 
-    /// Get the access rule for this room using a prefetched full access rule.
-    async fn access_rule_from_full_access_rules(
-        &self,
-        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
-    ) -> Result<AccessRule, Error> {
-        match full_access_rules {
-            Err(e) => return Err(e),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => Ok(e.content.access_rule),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
-                Err(Error::InsufficientData)
-            }
-            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { access_rule, .. } => {
-                    match access_rule {
-                        Some(value) => Ok(value),
-                        None => Err(Error::InsufficientData),
-                    }
-                }
-            },
-        }
-    }
+    /// Get the access_rules details (access_rule, encrypted, visibility) for this room.
+    pub async fn get_access_rules(&self) -> (Result<AccessRule, Error>, bool, Visibility) {
+        let (access_rule, encrypted_res, visibility_res) =
+            match self.get_access_rules_event_content().await {
+                Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => (
+                    Ok(e.content.access_rule),
+                    e.content.encrypted.ok_or(Error::InsufficientData),
+                    e.content.visibility.ok_or(Error::InsufficientData),
+                ),
+                Ok(SyncOrStrippedState::Stripped(e)) => (
+                    e.content.access_rule.ok_or(Error::InsufficientData),
+                    e.content.encrypted.ok_or(Error::InsufficientData),
+                    e.content.visibility.ok_or(Error::InsufficientData),
+                ),
+                Err(_) | Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => (
+                    Err(Error::InsufficientData),
+                    Err(Error::InsufficientData),
+                    Err(Error::InsufficientData),
+                ),
+            };
 
-    /// Get the access rule for this room.
-    pub async fn access_rule(&self) -> Result<AccessRule, Error> {
-        self.access_rule_from_full_access_rules(self.full_access_rules().await).await
-    }
-
-    /// Get the encrypted status for this room using a prefetched full access rule.
-    /// Force to true if not defined.
-    async fn is_encrypted_from_full_access_rules(
-        &self,
-        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
-    ) -> bool {
-        let result = match full_access_rules {
-            Err(e) => Err(e),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
-                match e.content.encrypted {
-                    None => Err(Error::InsufficientData),
-                    Some(encrypted_value) => Ok(encrypted_value),
-                }
-            }
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
-                Err(Error::InsufficientData)
-            }
-            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { encrypted, .. } => match encrypted {
-                    Some(value) => Ok(value),
-                    None => Err(Error::InsufficientData),
-                },
-            },
-        };
-        match result {
+        // When encrypted_res is in error, check the content of the last room.state.is_encrypted event.
+        // Consider the room to be not encrypted if we can't find these type of event, or if the last event content is not valid.
+        let encrypted = match encrypted_res {
             Ok(encrypted_value) => encrypted_value,
-            Err(_) => self.get_fallback_is_encrypted_value().await,
-        }
-    }
-
-    /// Get the encrypted status for this room. Force to true if not defined.
-    pub async fn is_encrypted(&self) -> bool {
-        self.is_encrypted_from_full_access_rules(self.full_access_rules().await).await
-    }
-
-    /// Get the latest encrypted status for this room.
-    /// This method is used as a last chance to get a value in `is_encrypted()` method
-    /// if the access rules event in the local store in unable to give a valid value.
-    /// This method check the content of the last room.state.is_encrypted event.
-    /// Consider the room to be not encrypted if we can't find these type of event, or if the last event content is not valid.
-    async fn get_fallback_is_encrypted_value(&self) -> bool {
-        self.latest_encryption_state().await.map(|state| state.is_encrypted()).unwrap_or(false)
-    }
-
-    /// Get the visibility status for this room in the room directory using a prefetched full access rule.
-    async fn visibility_from_full_access_rules(
-        &self,
-        full_access_rules: Result<SyncOrStrippedState<RoomAccessRulesEventContent>, Error>,
-    ) -> Visibility {
-        let result = match full_access_rules {
-            Err(e) => Err(e),
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Original(e))) => {
-                match e.content.visibility {
-                    None => Err(Error::InsufficientData),
-                    Some(visibility_value) => Ok(visibility_value),
-                }
-            }
-            Ok(SyncOrStrippedState::Sync(SyncStateEvent::Redacted(_))) => {
-                Err(Error::InsufficientData)
-            }
-            Ok(SyncOrStrippedState::Stripped(e)) => match e.content {
-                PossiblyRedactedRoomAccessRulesEventContent { visibility, .. } => {
-                    match visibility {
-                        Some(value) => Ok(value),
-                        None => Err(Error::InsufficientData),
-                    }
-                }
-            },
+            Err(_) => self
+                .latest_encryption_state()
+                .await
+                .map(|state| state.is_encrypted())
+                .unwrap_or(false),
         };
-        match result {
+
+        // TCHAP TODO : Remove this ugly cheat code when the backend returns complete access_rules (containing visibility state).
+        // When visibility_res is in error, we returns :
+        //     Visibility::Public when room is unencrypted
+        //     Visibility::Private when the room is encrypted.
+        let visibility = match visibility_res {
             Ok(visibility_value) => visibility_value,
-            Err(_) => self.get_fallback_room_visibility_value().await,
-        }
-    }
+            Err(_) => encrypted.then_some(Visibility::Private).unwrap_or(Visibility::Public),
+        };
 
-    /// Get the visibility status for this room in the room directory.
-    pub async fn visibility(&self) -> Visibility {
-        self.visibility_from_full_access_rules(self.full_access_rules().await).await
-    }
-
-    // TCHAP TODO : Remove this ugly cheat code when the backend returns complete access_rules (containing visibility state).
-    /// Requets the room visibility status for this room.
-    /// This method is used as a last chance to get a value in `visibility()` method
-    /// if the access rules event in the local store in unable to give a valid value.
-    /// This method return Visibility::Public when room is unencrypted or Visibility::Private when the room is encrypted.
-    async fn get_fallback_room_visibility_value(&self) -> Visibility {
-        self.is_encrypted().await.then_some(Visibility::Private).unwrap_or(Visibility::Public)
+        (access_rule, encrypted, visibility)
     }
     // end Tchap-specific : access_rules
 


### PR DESCRIPTION
<!-- description of the changes in this PR -->

- [ ] Public API changes documented in changelogs (optional)

Correction des délais inutiles lors de la récupération de access_rules.visibility via une requête.

Mise en place de fallback (car on ne récupère plus la valeur via une requête API) :
- À la création d'une room : 
  - `access_rules.encrypted` devient `access_rules.force_unencrypted_at_creation`
  - La valeur est "inversée", elle renvoie `true` si la room créée est privée & si l'utilisateur veut forcer la valeur encrypted à `false`
  - `access_rules.visibility` est toujours envoyé à la création

- À la lecture des infos d'une room : 
  - Accès aux externes : 'access_rules.rule' (valeur par défaut AccessRule::Restricted)
  - Salon public (forum) : 'access_rules.visibility' (valeur par défaut Visibility::Private)
  - Salon chiffré : lecture de l'event `latest_encryption_state` (valeur par défaut `false` si l'event n'existe pas ou si l'event ne contient pas `state.is_encrypted`)
  
  
